### PR TITLE
[sc-6014] display search results coming from the api

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ We're using `missdev` to load and have access to Nuclia’s frontend dependencie
 - **@nuclia/ui**: Svelte components and web components allowing to use Nuclia’s search capabilities
 - **@nuclia/prediction**: library used by Nuclia’s `SearchBar` widget
 
-The starter includes a simple example of Nuclia’s widgets integration in a SvelteKit application.
+The starter is a [SvelteKit](https://kit.svelte.dev/docs/introduction) application including:
+
+- a page showing a simple example of Nuclia’s widgets integration
+- a page showing an example of Nuclia’s `NucliaSearchResults` widget working with resulting loading from the API without using `NucliaSearchBar` widget
+- a simple layout allowing to navigate between the pages
 
 ## Developing
 

--- a/src/app.html
+++ b/src/app.html
@@ -6,6 +6,11 @@
     <link rel="icon" href="%sveltekit.assets%/favicon.ico" />
     <meta name="viewport" content="width=device-width" />
     %sveltekit.head%
+    <style>
+        body {
+            margin: 0;
+        }
+    </style>
   </head>
   <body data-sveltekit-preload-data="hover">
     <div style="display: contents">%sveltekit.body%</div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,0 +1,54 @@
+<script>
+  import {page} from '$app/stores';
+</script>
+
+<nav>
+  <a href="/" class:active={$page.url.pathname === '/'}>Main widgets</a>
+  <a href="/api-results" class:active={$page.url.pathname === '/api-results'}>Search API results</a>
+</nav>
+
+<main>
+  <slot></slot>
+</main>
+
+
+<style lang="scss">
+
+  main,
+  nav {
+    font-family: sans-serif;
+  }
+
+  main {
+    max-width: 100%;
+    margin: 0 auto;
+    padding: 1em;
+  }
+
+  nav {
+    background: #eeebff;
+    display: flex;
+    transition: background 0.16s ease-in-out;
+
+    a {
+      background: #eeebff;
+      color: #2600ff;
+      transition: color 0.16s ease-in-out, background 0.16s ease-in-out;
+      padding: 1rem;
+      text-decoration: none;
+
+      &:hover {
+        color: #1f00cc;
+      }
+
+      &:active {
+        color: #12007a;
+      }
+
+      &.active {
+        background: #fff;
+        color: #000;
+      }
+    }
+  }
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,48 +4,23 @@
   let knowledgeBoxId = '16375869-1037-460d-8648-b3ee9c9206c0';
 </script>
 
-<main>
-  <header>
-    <h1>Welcome to Nuclia UI starter project</h1>
+<header>
+  <div class="main-description">
+    <h2>Main widgets</h2>
+    <p>We have indexed the market outlook reports from the biggest financial institutions world-wide. <br>You can ask questions like "Will France be in recession in 2023" or
+      "Gold price evolution in 2023"</p>
+    <p>Below are the default Nuclia <code>SearchBar</code> and <code>SearchResults</code> widgets</p>
+  </div>
+  <NucliaSearchBar
+      knowledgebox={knowledgeBoxId}
+      lang="en"
+      placeholder="Ask your question here"
+      features="suggestions,permalink,answers" />
+</header>
 
-    <div class="example-description">
-      <p>We have indexed the market outlook reports from the biggest financial institutions world-wide. <br>You can ask questions like "Will France be in recession in 2023" or
-        "Gold price evolution in 2023"</p>
-      <p>Below are the default Nuclia <code>SearchBar</code> and <code>SearchResults</code> widgets</p>
-    </div>
-    <NucliaSearchBar
-        knowledgebox={knowledgeBoxId}
-        lang="en"
-        placeholder="Ask your question here"
-        features="suggestions,permalink,answers" />
-  </header>
-
-  <NucliaSearchResults />
-</main>
+<NucliaSearchResults />
 
 
 <style lang="scss">
-  main {
-    font-family: sans-serif;
-    padding: 1em;
-    max-width: 100%;
-    margin: 0 auto;
-
-    header {
-      align-items: center;
-      display: flex;
-      flex-direction: column;
-      margin-bottom: 2rem;
-    }
-
-    .example-description {
-      max-width: 944px;
-      margin-bottom: 1rem;
-      text-align: center;
-
-      p {
-        line-height: 1.25rem;
-      }
-    }
-  }
+  @import "common";
 </style>

--- a/src/routes/api-results/+page.svelte
+++ b/src/routes/api-results/+page.svelte
@@ -1,15 +1,75 @@
 <script lang="ts">
-  import { NucliaSearchResults } from '@nuclia/ui';
+  import {
+    activatePermalinks,
+    initNuclia,
+    initViewer,
+    NucliaSearchResults,
+    resetNuclia,
+    searchQuery,
+    searchResults,
+    searchState,
+    setLang,
+    unsubscribeAllEffects,
+  } from '@nuclia/ui';
+  import { ResourceProperties, Search } from '@nuclia/core';
+  import { onDestroy, onMount } from 'svelte';
+
+  const query = 'How the market will look like in 2023?';
+
+  onMount(() => {
+    // Setup Nuclia to use your KB and zone
+    const nuclia = initNuclia({
+      backend: 'https://nuclia.cloud/api',
+      zone: 'europe-1',
+      knowledgeBox: '16375869-1037-460d-8648-b3ee9c9206c0',
+    }, 'PUBLISHED', {
+      highlight: true,
+      features: {
+        permalink: true,
+      },
+    });
+
+    // Initialize the different effects we need to set up the features we need
+    initViewer();
+    activatePermalinks();
+
+    // Set lang so translations works
+    setLang(window.navigator.language.split('-')[0] || 'en');
+
+    // Find results for the query
+    // Features option defines the type of search we want to run, here we want fuzzy search and semantic results.
+    // See https://docs.stashify.cloud/docs/query/#features for details.
+    const features = [Search.Features.PARAGRAPH, Search.Features.VECTOR];
+    // In search options, we need to define which properties of the resources are returned.
+    // NucliaSearchResults requires the following to display the results properly:
+    const options = {show: [ResourceProperties.BASIC, ResourceProperties.VALUES, ResourceProperties.ORIGIN]};
+    nuclia.knowledgeBox.find(query, features, options).subscribe(results => {
+      if (results.type === 'findResults') {
+        // Update the store with the results:
+        // the query is required otherwise NucliaSearchResults doesn't display any results
+        searchQuery.set(query);
+        searchResults.set({results: results as Search.FindResults, append: false});
+      }
+    });
+  });
+
+  onDestroy(() => {
+    // Reset Nuclia and the state to start from scratch when navigating between pages
+    resetNuclia();
+    searchState.reset();
+    unsubscribeAllEffects();
+  });
 </script>
 
 <header>
   <div class="main-description">
     <h2>Search API results</h2>
     <p>
-      On this example, we loaded some search results directly from the API (ie. without using Nuclia
+      On this example, we load some search results directly from the API (ie. without using Nuclia
       <code>SearchBar</code> widget).
       <br>Then we display them in <code>NucliaSearchResults</code> widget.
     </p>
+    <p><strong>{query}</strong></p>
 
   </div>
 

--- a/src/routes/api-results/+page.svelte
+++ b/src/routes/api-results/+page.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import { NucliaSearchResults } from '@nuclia/ui';
+</script>
+
+<header>
+  <div class="main-description">
+    <h2>Search API results</h2>
+    <p>
+      On this example, we loaded some search results directly from the API (ie. without using Nuclia
+      <code>SearchBar</code> widget).
+      <br>Then we display them in <code>NucliaSearchResults</code> widget.
+    </p>
+
+  </div>
+
+</header>
+
+<NucliaSearchResults/>
+
+
+<style lang="scss">
+  @import "../common";
+</style>

--- a/src/routes/common.scss
+++ b/src/routes/common.scss
@@ -1,0 +1,16 @@
+header {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 2rem;
+}
+
+.main-description {
+  max-width: 944px;
+  margin-bottom: 1rem;
+  text-align: center;
+
+  p {
+    line-height: 1.25rem;
+  }
+}


### PR DESCRIPTION
- New page show casing search results coming from the API without the usage of Nuclia’s SearchBar
- Add layout and navigation between the two example pages
